### PR TITLE
Basic PicoVNA features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This driver is a wrapper around the [`vna`](https://pypi.org/project/vna/) libra
 - `bandwidth`, the filter bandwidth for the sweep in Hz, `RW`, `float`
 - `power_level`, the power amplitude of the sweep in dBm, `RW`, `float`
 - `sweep_params`, a list of sweep parameters defining the frequecies of the `start`, `stop`, and `step` for each component of the sweep, in Hz, `RW`, `float`
+- `sweep_nports`, the number of ports to be swept, selecting a reflection (`= 1`) or transmission (`= 2`) experiment, `RW`, `int`
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # tomato-picovna
+
+`tomato` driver for Pico Technologies PicoVNA network analysers.
+
+This driver is a wrapper around the [`vna`](https://pypi.org/project/vna/) library, which is part of the [PicoVNA 5 SDK](https://github.com/picotech/picovna5-examples). As such, the driver needs to be supplied with a location of the SDK using the *settings file* of `tomato`.
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 
 This driver is a wrapper around the [`vna`](https://pypi.org/project/vna/) library, which is part of the [PicoVNA 5 SDK](https://github.com/picotech/picovna5-examples). As such, the driver needs to be supplied with a location of the SDK using the *settings file* of `tomato`.
 
+## Supported functions
+
+### Capabilities
+- `linear_sweep` for performing a sweep of the reflection coefficient using linearly spaced points
+
+### Attributes
+- `temperature`, the temperature of the PicoVNA device, `RO`, `float`
+- `bandwidth`, the filter bandwidth for the sweep in Hz, `RW`, `float`
+- `power_level`, the power amplitude of the sweep in dBm, `RW`, `float`
+- `sweep_params`, a list of sweep parameters defining the frequecies of the `start`, `stop`, and `step` for each component of the sweep, in Hz, `RW`, `float`
+
+## Contributors
+
+- Peter Kraus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["version"]
+name = "tomato-picovna"
+authors = [
+  {name="Peter Kraus", email="peter.kraus@ceramics.tu-berlin.de"},
+]
+
+description = "This package is a part of tomato. It has been made for the automation of PicoVNA network analysers."
+readme = "README.md"
+requires-python = ">= 3.10, < 3.12"
+dependencies = [
+    "vna >= 0.0.5",
+    "psutil >= 5.9",
+    "tomato >= 1.0",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Operating System :: OS Independent",
+]
+
+[project.optional-dependencies]
+testing = [
+    "pytest",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/dgbowl/tomato-picovna"
+"Bug Tracker" = "https://github.com/dgbowl/tomato-picovna/issues"
+
+[tool.setuptools-git-versioning]
+enabled = true
+dev_template = "{tag}.dev{ccount}"
+dirty_template = "{tag}.dev{ccount}"
+
+[tool.ruff]

--- a/src/tomato_picovna/__init__.py
+++ b/src/tomato_picovna/__init__.py
@@ -93,7 +93,6 @@ class DriverInterface(ModelInterface):
                 "bandwidth": Attr(type=float, units="Hz", rw=True),
                 "power_level": Attr(type=float, units="dBm", rw=True),
                 "sweep_params": Attr(type=Any, rw=True, status=True),
-                "freq": Attr(type=Any, units="Hz"),
             }
             return attrs_dict
 

--- a/src/tomato_picovna/__init__.py
+++ b/src/tomato_picovna/__init__.py
@@ -1,0 +1,231 @@
+from typing import Any, Optional
+from types import ModuleType
+from tomato.driverinterface_1_0 import ModelInterface, Attr, Task, Reply, in_devmap
+from pathlib import Path
+import psutil
+import sys
+import importlib
+from time import perf_counter, sleep
+from pydantic import BaseModel, model_validator
+import numpy as np
+import logging
+from datetime import datetime
+from xarray import Dataset
+
+vna: ModuleType = None
+
+BANDWIDTH_SET = {10, 50, 100, 500, 1_000, 5_000, 10_000, 35_000, 70_000, 140_000}
+POINTS_SET = {11, 51, 101, 201, 401, 801, 1001, 2001, 3001, 4001, 5001, 6001, 7001}
+logger = logging.getLogger(__name__)
+
+
+def estimate_sweep_time(bw: int, npoints: int):
+    # Parameters obtained using a curve fit to various npoints & bandwidths
+    c0, c1, c2 = [7.17562593e-01, 1.83389054e00, 1.28624374e-04]
+    return c0 + npoints * (c1 / bw + c2)
+
+
+class Sweep(BaseModel):
+    start: float
+    stop: float
+    points: Optional[int] = None
+    step: Optional[float] = None
+
+    @model_validator(mode="after")
+    def check_points_or_every(self):
+        if self.points is None and self.step is None:
+            raise ValueError("Must supply either 'points' or 'every'.")
+        if self.points is not None and self.step is not None:
+            raise ValueError("Must supply either 'points' or 'every', not both.")
+        return self
+
+
+class DriverInterface(ModelInterface):
+    def __init__(self, settings=None):
+        super().__init__(settings)
+        if "sdkpath" not in self.settings:
+            raise RuntimeError(
+                "Cannot instantiate tomato-picovna without supplying a sdkpath"
+            )
+        path = Path(self.settings["sdkpath"])
+        if psutil.WINDOWS:
+            path = path / "windows"
+        elif psutil.LINUX:
+            path = path / "linux_x64"
+        else:
+            raise RuntimeError("Unsupported OS")
+        if sys.version_info[1] == 10:
+            path = path / "python310"
+        elif sys.version_info[1] == 11:
+            path = path / "python311"
+        sys.path.append(str(path))
+
+        global vna
+        vna = importlib.import_module("vna.vna")
+
+    class DeviceManager(ModelInterface.DeviceManager):
+        instrument: Any
+        measurement: Any
+        frequency_unit: str = "Hz"
+        frequency_min: float
+        frequency_max: float
+
+        _bandwidth: float = None
+        _power_level: float = None
+        _sweep_params: list[Sweep] = list()
+
+        @property
+        def _temperature(self):
+            return self.instrument.getTemperature()
+
+        def __init__(
+            self, driver: ModelInterface, key: tuple[str, int], **kwargs: dict
+        ):
+            super().__init__(driver, key, **kwargs)
+            self.instrument = vna.Device.open(f"{key[1]}")
+            info = self.instrument.getInfo()
+            self.frequency_min = info.minSweepFrequencyHz
+            self.frequency_max = info.maxSweepFrequencyHz
+
+        def attrs(self, **kwargs: dict) -> dict[str, Attr]:
+            attrs_dict = {
+                "temperature": Attr(type=float, units="Celsius", status=True),
+                "bandwidth": Attr(type=float, units="Hz", rw=True),
+                "power_level": Attr(type=float, units="dBm", rw=True),
+                "sweep_params": Attr(type=Any, rw=True, status=True),
+                "freq": Attr(type=Any, units="Hz"),
+            }
+            return attrs_dict
+
+        def set_attr(self, attr: str, val: Any, **kwargs: dict):
+            if attr not in self.attrs():
+                raise ValueError(f"Unknown attr: {attr!r}")
+            if not self.attrs()[attr].rw:
+                raise ValueError(f"Read only attr: {attr!r}")
+            if attr == "bandwidth":
+                if val not in BANDWIDTH_SET:
+                    raise ValueError(f"'bandwidth' of {val} is not permitted")
+                setattr(self, f"_{attr}", val)
+            elif attr == "power_level":
+                setattr(self, f"_{attr}", val)
+            elif attr in {"sweep_params"}:
+                self._sweep_params = [Sweep(**item) for item in val]
+
+        def get_attr(self, attr: str, **kwargs: dict):
+            if attr not in self.attrs():
+                raise ValueError(f"Unknown attr: {attr!r}")
+            if hasattr(self, f"_{attr}"):
+                return getattr(self, f"_{attr}")
+
+        def capabilities(self, **kwargs: dict) -> set:
+            capabs = {"linear_sweep"}
+            return capabs
+
+        def prepare_task(self, task, **kwargs):
+            super().prepare_task(task, **kwargs)
+            self._build_sweep()
+
+        def do_task(self, task: Task, **kwargs: dict):
+            uts = datetime.now().timestamp()
+            t0 = perf_counter()
+            ret = self.instrument.performMeasurement(self.measurement)
+            dt = perf_counter() - t0
+            if dt > task.sampling_interval:
+                logger.warning(
+                    "'task.sampling_interval' of %f s is too short, last sweep took %f s",
+                    task.sampling_interval,
+                    dt,
+                )
+            else:
+                logger.debug("last sweep took %f s", dt)
+            self.data["uts"].append(uts)
+            self.data["temperature"].append(self._temperature)
+            freq = []
+            real = []
+            imag = []
+            for pt in ret:
+                freq.append(pt.measurementFrequencyHz)
+                real.append(pt.s11.real)
+                imag.append(pt.s11.imag)
+            self.data["freq"].append(freq)
+            self.data["Re(S11)"].append(real)
+            self.data["Im(S11)"].append(imag)
+
+        def _build_sweep(self):
+            logger.debug("building a sweep")
+            mc = vna.MeasurementConfiguration()
+            for sweep in self._sweep_params:
+                if sweep.step is not None:
+                    points = np.arange(sweep.start, sweep.stop + 1, sweep.step)
+                elif sweep.points is not None:
+                    points = np.linspace(sweep.start, sweep.stop, num=sweep.points)
+                    points = np.around(points)
+                logger.debug("adding a sweep section with %d points", len(points))
+                for p in points:
+                    pt = vna.MeasurementPoint()
+                    pt.frequencyHz = p
+                    pt.powerLeveldBm = self._power_level
+                    pt.bandwidthHz = self._bandwidth
+                    mc.addPoint(pt)
+            logger.debug("sweep with %d total points built", len(mc.getPoints()))
+            self.measurement = mc
+
+    @in_devmap
+    def task_data(self, key: tuple, **kwargs) -> Reply:
+        data = self.devmap[key].get_data(**kwargs)
+
+        if len(data) == 0:
+            return Reply(success=False, msg="found no new datapoints")
+
+        attrs = self.devmap[key].attrs(**kwargs)
+        coords = {
+            "uts": data.pop("uts"),
+            "freq": (("uts", "freq"), data.pop("freq"), {"units": "Hz"}),
+        }
+        data_vars = {}
+        for k, v in data.items():
+            if k.startswith("Re") or k.startswith("Im"):
+                data_vars[k] = (("uts", "freq"), v)
+            else:
+                units = {} if attrs[k].units is None else {"units": attrs[k].units}
+                data_vars[k] = ("uts", v, units)
+        ds = Dataset(data_vars=data_vars, coords=coords)
+        return Reply(success=True, msg=f"found {len(data)} new datapoints", data=ds)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    print(f"{vna=}")
+    settings = {
+        "sdkpath": r"C:\Users\Kraus\Downloads\picovna5_sdk_v_5_2_5\picovna5_sdk_v_5_2_5\python"
+    }
+    kwargs = dict(address="A0171", channel="11328")
+    interface = DriverInterface(settings=settings)
+    interface.dev_register(**kwargs)
+    component = interface.devmap[("A0171", "11328")]
+    print(f"{interface=}")
+    print(f"{component=}")
+    print(f"{vna=}")
+
+    task = Task(
+        component_tag="bla",
+        max_duration=10,
+        sampling_interval=5,
+        technique_name="linear_sweep",
+        technique_params={
+            "bandwidth": 100,
+            "power_level": -3,
+            "sweep_params": [
+                # dict(start=2_000_000_000, stop=2_500_000_000, points=101),
+                dict(start=2_000_000_000, stop=2_500_000_000, step=5_000_000),
+            ],
+        },
+    )
+
+    interface.task_start(task=task, **kwargs)
+    sleep(1)
+    while interface.task_status(**kwargs).data["running"]:
+        print(f"{interface.task_status(**kwargs)=}")
+        sleep(1)
+    data = interface.task_data(**kwargs)
+    print(f"{data=}")

--- a/src/tomato_picovna/__init__.py
+++ b/src/tomato_picovna/__init__.py
@@ -32,11 +32,11 @@ class Sweep(BaseModel):
     step: Optional[float] = None
 
     @model_validator(mode="after")
-    def check_points_or_every(self):
+    def check_points_or_step(self):
         if self.points is None and self.step is None:
-            raise ValueError("Must supply either 'points' or 'every'.")
+            raise ValueError("Must supply either 'points' or 'step'.")
         if self.points is not None and self.step is not None:
-            raise ValueError("Must supply either 'points' or 'every', not both.")
+            raise ValueError("Must supply either 'points' or 'step', not both.")
         return self
 
 


### PR DESCRIPTION
Adds the ability to run `linear_sweep` by supplying parameters such as `bandwidth`, `power_level` and the description of `sweep_params` using a defined `Sweep` class. By default returns only a reflection measurement (i.e. only `Re(S11)` and `Im(S11)` parameters), but can be configured to return all 4 parameter pairs by specifying `sweep_nports = 2`.

Stores the last executed sweep on `last_sweep`, which is `None` if no previous sweep was performed.